### PR TITLE
Get JS startpoint to same state as Java/CSharp, so workbooks align

### DIFF
--- a/features/hear_shout.feature
+++ b/features/hear_shout.feature
@@ -3,13 +3,13 @@ Feature: Hear Shout
   Shouts have a range of approximately 1000m
 
   Scenario: In range shout is heard
-    Given Lucy is at [0, 0]
-    And Sean is at [0, 900]
+    Given Lucy is at 0, 0
+    And Sean is at 0, 900
     When Sean shouts
     Then Lucy should hear Sean
 
   Scenario: Out of range shout is not heard
-    Given Lucy is at [0, 0]
-    And Sean is at [0, 1100]
+    Given Lucy is at 0, 0
+    And Sean is at 0, 1100
     When Sean shouts
     Then Lucy should hear nothing

--- a/features/step_definitions/shout_steps.js
+++ b/features/step_definitions/shout_steps.js
@@ -8,12 +8,12 @@ defineSupportCode(function({Given, When, Then}) {
   const ARBITARY_MESSAGE = 'Hello, world'
   var shouty = new Shouty()
 
-  Given(/^Lucy is at \[(\d+), (\d+)\]$/, function (x, y, callback) {
+  Given(/^Lucy is at (\d+), (\d+)$/, function (x, y, callback) {
     shouty.setLocation('Lucy', new Coordinate(x, y))
     callback()
   });
 
-  Given(/^Sean is at \[(\d+), (\d+)\]$/, function (x, y, callback) {
+  Given(/^Sean is at (\d+), (\d+)$/, function (x, y, callback) {
     shouty.setLocation('Sean', new Coordinate(x, y))
     callback()
   });

--- a/features/step_definitions/shout_steps.js
+++ b/features/step_definitions/shout_steps.js
@@ -6,29 +6,30 @@ var {defineSupportCode} = require('cucumber');
 
 defineSupportCode(function({Given, When, Then}) {
   const ARBITARY_MESSAGE = 'Hello, world'
+  var shouty = new Shouty()
 
   Given(/^Lucy is at \[(\d+), (\d+)\]$/, function (x, y, callback) {
-    this.shouty.setLocation('Lucy', new Coordinate(x, y))
+    shouty.setLocation('Lucy', new Coordinate(x, y))
     callback()
   });
 
   Given(/^Sean is at \[(\d+), (\d+)\]$/, function (x, y, callback) {
-    this.shouty.setLocation('Sean', new Coordinate(x, y))
+    shouty.setLocation('Sean', new Coordinate(x, y))
     callback()
   });
 
   When(/^Sean shouts$/, function (callback) {
-    this.shouty.shout('Sean', ARBITARY_MESSAGE)
+    shouty.shout('Sean', ARBITARY_MESSAGE)
     callback()
   });
 
   Then(/^Lucy should hear Sean$/, function (callback) {
-    assert.equal(Object.keys(this.shouty.getMessagesHeardBy('Lucy')).length, 1)
+    assert.equal(Object.keys(shouty.getMessagesHeardBy('Lucy')).length, 1)
     callback()
   });
 
   Then(/^Lucy should hear nothing$/, function (callback) {
-    assert.equal(Object.keys(this.shouty.getMessagesHeardBy('Lucy')).length, 0)
+    assert.equal(Object.keys(shouty.getMessagesHeardBy('Lucy')).length, 0)
     callback()
   });
 

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,8 +1,6 @@
 var {defineSupportCode} = require('cucumber');
-var Shouty = require('../../lib/shouty');
 
 function CustomWorld() {
-  this.shouty = new Shouty()
 }
 
 defineSupportCode(function({setWorldConstructor}) {


### PR DESCRIPTION
The current start-point shares the Shouty object via the World, but the workbook flow wants the build to fail when steps are split over two step definition files. So, this PR uses a Shouty object local to the step definitions, so that JavaScript students can work through the same flow as Java/CSharp students.