### PR TITLE
use yarn instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Or simply [download](https://github.com/cucumber-ltd/shouty.js/archive/master.zi
 
 ## Install Cucumber and other dependencies
 
-    npm install
+    yarn install
 
 After this, Cucumber is in `./node_modules/.bin/cucumber.js`
 For convenience you can run it with `./cucumber`.
 
 ## Run all the tests
 
-    npm test
+    yarn test
 
 ## Run all the tests in the background
 
-    npm run watch
+    yarn run watch

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "mocha": "mocha",
     "cucumber": "cucumber-js",
-    "test": "npm run mocha; npm run cucumber --",
+    "test": "yarn run mocha && yarn run cucumber --",
     "watch": "npm-watch"
   },
   "repository": {


### PR DESCRIPTION
@aslakhellesoy 

Use `yarn` instead of `npm` to run scripts to avoid the awful npm log. Also use `&&` instead of `;` so it stops executing if the unit tests fail.

```
yarn test v0.24.5
$ yarn run mocha && yarn run cucumber -- 
yarn run v0.24.5
$ mocha 


  Coordinate
    ✓ should calculate the distance from itself
    1) should calculate the distance from another coordinate along X axis


  1 passing (8ms)
  1 failing

  1) Coordinate should calculate the distance from another coordinate along X axis:

      AssertionError: 0 == 1000
      + expected - actual

      -0
      +1000
      
      at Context.it (test/coordinate.test.js:15:12)



error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
```
vs
```
> Shouty@1.0.0 test /Users/charlesrudolph/projects/shouty.js
> npm run mocha; npm run cucumber --


> Shouty@1.0.0 mocha /Users/charlesrudolph/projects/shouty.js
> mocha



  Coordinate
    ✓ should calculate the distance from itself
    1) should calculate the distance from another coordinate along X axis


  1 passing (7ms)
  1 failing

  1) Coordinate should calculate the distance from another coordinate along X axis:

      AssertionError: 0 == 1000
      + expected - actual

      -0
      +1000
      
      at Context.it (test/coordinate.test.js:15:12)




npm ERR! Darwin 16.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "mocha"
npm ERR! node v7.3.0
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! Shouty@1.0.0 mocha: `mocha`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the Shouty@1.0.0 mocha script 'mocha'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the Shouty package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     mocha
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs Shouty
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls Shouty
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/charlesrudolph/.npm/_logs/2017-06-22T12_49_58_129Z-debug.log

> Shouty@1.0.0 cucumber /Users/charlesrudolph/projects/shouty.js
> cucumber-js

Feature: Hear Shout

    Shouts have a range of approximately 1000m

  Scenario: In range shout is heard
  ✔ Given Lucy is at 0, 0
  ✔ And Sean is at 0, 900
  ✔ When Sean shouts
  ✔ Then Lucy should hear Sean

  Scenario: Out of range shout is not heard
  ✔ Given Lucy is at 0, 0
  ✔ And Sean is at 0, 1100
  ✔ When Sean shouts
  ✖ Then Lucy should hear nothing

Failures:

1) Scenario: Out of range shout is not heard - features/hear_shout.feature:11
   Step: Then Lucy should hear nothing - features/hear_shout.feature:15
   Step Definition: features/step_definitions/shout_steps.js:30
   Message:
     AssertionError: 1 == 0
         + expected - actual

         -1
         +0
     
         at CustomWorld.<anonymous> (/Users/charlesrudolph/projects/shouty.js/features/step_definitions/shout_steps.js:31:12)

2 scenarios (1 failed, 1 passed)
8 steps (1 failed, 7 passed)
0m00.004s

npm ERR! Darwin 16.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "cucumber" "--"
npm ERR! node v7.3.0
npm ERR! npm  v4.2.0
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! Shouty@1.0.0 cucumber: `cucumber-js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the Shouty@1.0.0 cucumber script 'cucumber-js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the Shouty package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     cucumber-js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs Shouty
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls Shouty
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/charlesrudolph/.npm/_logs/2017-06-22T12_49_58_944Z-debug.log
npm ERR! Test failed.  See above for more details.
```
