### PR TITLE
update dependency: cucumber

### DIFF
--- a/features/step_definitions/shout_steps.js
+++ b/features/step_definitions/shout_steps.js
@@ -2,33 +2,30 @@ const assert = require('assert')
 const Shouty = require('../../lib/shouty')
 const Coordinate = require('../../lib/coordinate')
 
-const {defineSupportCode} = require('cucumber')
+const {Before, Given, When, Then} = require('cucumber')
 
-defineSupportCode(({Before, Given, When, Then}) => {
-  const ARBITARY_MESSAGE = 'Hello, world'
-  let shouty
-  Before(function() {
-    shouty = new Shouty()
-  })
+const ARBITARY_MESSAGE = 'Hello, world'
+let shouty
+Before(function() {
+  shouty = new Shouty()
+})
 
-  Given('Lucy is at {int}, {int}', function (x, y) {
-    shouty.setLocation('Lucy', new Coordinate(x, y))
-  })
+Given('Lucy is at {int}, {int}', function (x, y) {
+  shouty.setLocation('Lucy', new Coordinate(x, y))
+})
 
-  Given('Sean is at {int}, {int}', function (x, y) {
-    shouty.setLocation('Sean', new Coordinate(x, y))
-  })
+Given('Sean is at {int}, {int}', function (x, y) {
+  shouty.setLocation('Sean', new Coordinate(x, y))
+})
 
-  When('Sean shouts', function () {
-    shouty.shout('Sean', ARBITARY_MESSAGE)
-  })
+When('Sean shouts', function () {
+  shouty.shout('Sean', ARBITARY_MESSAGE)
+})
 
-  Then('Lucy should hear Sean', function () {
-    assert.equal(shouty.getMessagesHeardBy('Lucy').size, 1)
-  })
+Then('Lucy should hear Sean', function () {
+  assert.equal(shouty.getMessagesHeardBy('Lucy').size, 1)
+})
 
-  Then('Lucy should hear nothing', function () {
-    assert.equal(shouty.getMessagesHeardBy('Lucy').size, 0)
-  })
-
+Then('Lucy should hear nothing', function () {
+  assert.equal(shouty.getMessagesHeardBy('Lucy').size, 0)
 })

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,8 +1,6 @@
-const { defineSupportCode } = require('cucumber')
+const { setWorldConstructor } = require('cucumber')
 
 function CustomWorld() {
 }
 
-defineSupportCode(function({ setWorldConstructor }) {
-  setWorldConstructor(CustomWorld)
-})
+setWorldConstructor(CustomWorld)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "watch": {
     "mocha": "{lib,test}/**/*.js",
     "cucumber": {
-      "patterns": ["lib", "features"],
+      "patterns": [
+        "lib",
+        "features"
+      ],
       "extensions": "js,feature"
     }
   },
@@ -31,7 +34,7 @@
   },
   "homepage": "https://github.com/cucumber-ltd/shouty.js",
   "devDependencies": {
-    "cucumber": "^v2.0.0-rc.7",
+    "cucumber": "^2.3.1",
     "esprima": "^3.1.3",
     "mocha": "^3.2.0",
     "npm-watch": "^0.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,17 +244,17 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-cucumber-expressions@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cucumber-expressions/-/cucumber-expressions-1.0.4.tgz#5d59d8ee39e18899431f49de16037e3161b8f31d"
+cucumber-expressions@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cucumber-expressions/-/cucumber-expressions-3.0.0.tgz#4cf424813dae396cc9dab714b8104b459befc32c"
 
 cucumber-tag-expressions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cucumber-tag-expressions/-/cucumber-tag-expressions-1.0.0.tgz#5dc27ae3073acde1db3aa7cf4d9609a42f15ee5d"
 
-cucumber@^v2.0.0-rc.7:
-  version "2.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/cucumber/-/cucumber-2.0.0-rc.7.tgz#96c3abd45ba60c99e5205e4070991533559bb27e"
+cucumber@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/cucumber/-/cucumber-2.3.1.tgz#3791a51ffd0c61462ad57fdb8ed111d55b51cde3"
   dependencies:
     assertion-error-formatter "^2.0.0"
     babel-runtime "^6.11.6"
@@ -262,19 +262,21 @@ cucumber@^v2.0.0-rc.7:
     cli-table "^0.3.1"
     colors "^1.1.2"
     commander "^2.9.0"
-    cucumber-expressions "^1.0.3"
+    cucumber-expressions "^3.0.0"
     cucumber-tag-expressions "^1.0.0"
     duration "^0.2.0"
     figures "2.0.0"
-    gherkin "^4.0.0"
+    gherkin "^4.1.0"
     glob "^7.0.0"
-    indent-string "3.0.0"
+    indent-string "^3.1.0"
     is-generator "^1.0.2"
     is-stream "^1.1.0"
     lodash "^4.0.0"
     mz "^2.4.0"
+    progress "^2.0.0"
+    resolve "^1.3.3"
     stack-chain "^1.3.5"
-    stacktrace-js "^1.3.0"
+    stacktrace-js "^2.0.0"
     string-argv "0.0.2"
     upper-case-first "^1.1.2"
     util-arity "^1.0.2"
@@ -292,17 +294,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@^2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
-
-debug@^2.2.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
-  dependencies:
-    ms "0.7.2"
 
 deep-extend@~0.4.0:
   version "0.4.1"
@@ -356,11 +352,11 @@ end-of-stream@1.0.0:
   dependencies:
     once "~1.3.0"
 
-error-stack-parser@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
+error-stack-parser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.1.tgz#a3202b8fb03114aa9b40a0e3669e48b2b65a010a"
   dependencies:
-    stackframe "^0.3.1"
+    stackframe "^1.0.3"
 
 es5-ext@^0.10.7, es5-ext@~0.10.11, es5-ext@~0.10.2:
   version "0.10.12"
@@ -541,9 +537,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gherkin@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gherkin/-/gherkin-4.0.0.tgz#79dce04d1223ea43b4862a76be5ce8f89c12c32c"
+gherkin@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/gherkin/-/gherkin-4.1.3.tgz#11687db93976df97633125a6b2228a1a4bfdfa24"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -558,20 +554,9 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.0.5:
+glob@7.0.5, glob@^7.0.0, glob@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -659,11 +644,9 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
-indent-string@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.0.0.tgz#ddab23d32113ef04b67ab4cf4a0951c1a85fd60c"
-  dependencies:
-    repeating "^3.0.0"
+indent-string@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
 
 infinity-agent@^2.0.0:
   version "2.0.3"
@@ -995,10 +978,6 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-
 mz@^2.4.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.6.0.tgz#c8b8521d958df0a4f2768025db69c719ee4ef1ce"
@@ -1154,6 +1133,10 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
@@ -1181,6 +1164,10 @@ preserve@^0.2.0:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 ps-tree@^1.0.1:
   version "1.1.0"
@@ -1283,10 +1270,6 @@ repeating@^1.1.2:
   dependencies:
     is-finite "^1.0.0"
 
-repeating@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-3.0.0.tgz#f4c376fdd2015761f6f96f4303b1224d581e802f"
-
 request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
@@ -1311,6 +1294,12 @@ request@^2.79.0:
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
+
+resolve@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
 
 rimraf@2, rimraf@~2.5.1, rimraf@~2.5.4:
   version "2.5.4"
@@ -1379,34 +1368,30 @@ stack-chain@^1.3.5:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
 
-stack-generator@^1.0.7:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-1.1.0.tgz#36f6a920751a6c10f499a13c32cbb5f51a0b8b25"
+stack-generator@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.1.tgz#b37d8b0d9a2a6e52c06cc8e185f98f199fb63804"
   dependencies:
-    stackframe "^1.0.2"
+    stackframe "^1.0.3"
 
-stackframe@^0.3.1, stackframe@~0.3:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
+stackframe@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.3.tgz#fe64ab20b170e4ce49044b126c119dfa0e5dc7cc"
 
-stackframe@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.2.tgz#162245509c687d328b14f671dab8fdb755b1e1e8"
-
-stacktrace-gps@^2.4.3:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-2.4.4.tgz#69c827e9d6d6f41cf438d7f195e2e3cbfcf28c44"
+stacktrace-gps@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.1.tgz#1e6f4997841d2b5bdabab9e6117e965ebbe64286"
   dependencies:
     source-map "0.5.6"
-    stackframe "~0.3"
+    stackframe "^1.0.3"
 
-stacktrace-js@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-1.3.1.tgz#67cab2589af5c417b962f7369940277bb3b6a18b"
+stacktrace-js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.0.tgz#776ca646a95bc6c6b2b90776536a7fc72c6ddb58"
   dependencies:
-    error-stack-parser "^1.3.6"
-    stack-generator "^1.0.7"
-    stacktrace-gps "^2.4.3"
+    error-stack-parser "^2.0.1"
+    stack-generator "^2.0.1"
+    stacktrace-gps "^3.0.1"
 
 stream-combiner@~0.0.4:
   version "0.0.4"


### PR DESCRIPTION
removes the need for `defineSupportCode` as we now support direct imports