### PR TITLE
Revert shout_steps.js to basic Cucumber expression version

### DIFF
--- a/features/step_definitions/shout_steps.js
+++ b/features/step_definitions/shout_steps.js
@@ -10,8 +10,12 @@ Before(function() {
   shouty = new Shouty()
 })
 
-Given('{word} is at {coordinate}', function (name, coordinate) {
-  shouty.setLocation(name, coordinate)
+Given('Lucy is at {int}, {int}', function (x, y) {
+  shouty.setLocation('Lucy', new Coordinate(x, y))
+})
+
+Given('Sean is at {int}, {int}', function (x, y) {
+  shouty.setLocation('Sean', new Coordinate(x, y))
 })
 
 When('Sean shouts', function () {


### PR DESCRIPTION
During fab2dbff395e18ebdf095530595c19759c83b94f we moved the `shout_steps.js` to be out of sync with how the training material works.

We went from:

```
  Given('Lucy is at {int}, {int}', function (x, y) {
    shouty.setLocation('Lucy', new Coordinate(x, y))
  })

  Given('Sean is at {int}, {int}', function (x, y) {
    shouty.setLocation('Sean', new Coordinate(x, y))
  })
```

To:

```
Given('{word} is at {coordinate}', function (name, coordinate) {
  shouty.setLocation(name, coordinate)
})
```

This is what we ask the candidates to do as they progress to using their own expression types and remove step duplication.

This also changes the initial error from a scenario failure to an unknown expression error:

```
./cucumber features/hear_shout.feature
ReferenceError: describe is not defined
    at Object.<anonymous> (/Users/joejag/projects/cuke/shouty.js/node_modules/gherkin/test/stream/event_stream_test.js:5:1)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at /Users/joejag/projects/cuke/shouty.js/node_modules/cucumber/lib/cli/index.js:153:16
    at Array.forEach (<anonymous>)
    at Cli.getSupportCodeLibrary (/Users/joejag/projects/cuke/shouty.js/node_modules/cucumber/lib/cli/index.js:152:24)
    at Cli.<anonymous> (/Users/joejag/projects/cuke/shouty.js/node_modules/cucumber/lib/cli/index.js:171:39)
    at Generator.next (<anonymous>)
    at Generator.tryCatcher (/Users/joejag/projects/cuke/shouty.js/node_modules/bluebird/js/release/util.js:16:23)
    at PromiseSpawn._promiseFulfilled (/Users/joejag/projects/cuke/shouty.js/node_modules/bluebird/js/release/generators.js:97:49)
    at Promise._settlePromise (/Users/joejag/projects/cuke/shouty.js/node_modules/bluebird/js/release/promise.js:574:26)
```

This PR reverts to the previous version of the step defs. So the training material is aligned and the initial error seen by participants is:

```
./cucumber
.........F

Failures:

1) Scenario: Out of range shout is not heard # features/hear_shout.feature:11
   ✔ Before # features/step_definitions/shout_steps.js:9
   ✔ Given Lucy is at 0, 0 # features/step_definitions/shout_steps.js:13
   ✔ And Sean is at 0, 1100 # features/step_definitions/shout_steps.js:13
   ✔ When Sean shouts # features/step_definitions/shout_steps.js:17
   ✖ Then Lucy should hear nothing # features/step_definitions/shout_steps.js:25
       AssertionError [ERR_ASSERTION]: 1 == 0
           + expected - actual

           -1
           +0

           at CustomWorld.<anonymous> (/Users/joejag/projects/cuke/shouty.js/features/step_definitions/shout_steps.js:26:10)

2 scenarios (1 failed, 1 passed)
8 steps (1 failed, 7 passed)
0m00.005s
```